### PR TITLE
hotfix RefundExternalTransaction

### DIFF
--- a/lib/pokepay_partner_ruby_sdk/request/refund_external_transaction.rb
+++ b/lib/pokepay_partner_ruby_sdk/request/refund_external_transaction.rb
@@ -5,7 +5,7 @@ require "pokepay_partner_ruby_sdk/response/external_transaction"
 module Pokepay::Request
   class RefundExternalTransaction < Request
     def initialize(transaction_id, rest_args = {})
-      @path = "/external-transaction" + "/" + event_id + "/refund"
+      @path = "/external-transactions" + "/" + transaction_id + "/refund"
       @method = "POST"
       @body_params = {  }.merge(rest_args)
       @response_class = Pokepay::Response::ExternalTransaction


### PR DESCRIPTION
partner.yamlにtypoがあり、SDK生成時に間違ったurlを指していた。
partner.yamlの修正はサーバリリースが必要なので次回直すとして、SDKを直接修正する